### PR TITLE
Update to use shift-calculated table to bit-shift.

### DIFF
--- a/life_game/life_game.cpp
+++ b/life_game/life_game.cpp
@@ -88,8 +88,10 @@ bool evaluate (uint8_t* current, uint8_t x, uint8_t y) {
 void setAlive (uint8_t* live, uint8_t x, uint8_t y) {
   uint16_t ptr  = y / 8 * MAX_WIDTH + x;
   uint8_t  mask = _BV(y % 8);
+  const uint8_t patterns[] = { 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80 };
+  
 
-  live[ptr] = live[ptr] | mask;
+  live[ptr] = live[ptr] | patterns[y & 0x7];
 }
 
 void moveToNextGeneration (uint8_t* buffer, uint8_t* live) {


### PR DESCRIPTION
Original source is bit-shifting every time drawing a dot.
To improve processing speed, I need to update to use calculated table instead of bit-shifting every time.